### PR TITLE
Remove unused foldable-traversable dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,7 +12,6 @@
   "license": "MIT",
   "dependencies": {
     "purescript-profunctor":  "~0.0.1",
-    "purescript-foldable-traversable":  "~0.1.4",
     "purescript-monoid":      "~0.1.4",
     "purescript-arrays":      "~0.3.0",
     "purescript-arrows":      "~0.1.1",


### PR DESCRIPTION
Unless this _should_ have `Foldable` and `Traversable` instances and is just missing implementations?

For release as `v0.3.0`.