### PR TITLE
Introduce purs-tidy formatter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
 
       - name: Set up a PureScript toolchain
         uses: purescript-contrib/setup-purescript@main
+        with:
+          purs-tidy: "latest"
 
       - name: Cache PureScript dependencies
         uses: actions/cache@v2
@@ -32,3 +34,6 @@ jobs:
 
       - name: Run tests
         run: spago test --no-install
+
+      - name: Check formatting
+        run: purs-tidy check src test

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 !.gitignore
 !.github
 !.editorconfig
+!.tidyrc.json
 
 output
 generated-docs

--- a/.tidyrc.json
+++ b/.tidyrc.json
@@ -1,0 +1,10 @@
+{
+  "importSort": "source",
+  "importWrap": "source",
+  "indent": 2,
+  "operatorsFile": null,
+  "ribbon": 1,
+  "typeArrowPlacement": "first",
+  "unicode": "never",
+  "width": null
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ New features:
 Bugfixes:
 
 Other improvements:
+- Added `purs-tidy` formatter (#51 by @thomashoneyman)
 
 ## [v6.1.0](https://github.com/purescript-contrib/purescript-machines/releases/tag/v6.1.0) - 2021-05-06
 

--- a/src/Data/Machine/Mealy.purs
+++ b/src/Data/Machine/Mealy.purs
@@ -63,7 +63,8 @@ runMealyT (MealyT f) = f
 -- | in `g`, given a natural transformation from `f` to `g`.
 hoistMealyT :: forall f g i. Functor g => (f ~> g) -> MealyT f i ~> MealyT g i
 hoistMealyT f2g (MealyT goF) = MealyT goG
-  where goG i = hoistStep f2g <$> f2g (goF i)
+  where
+  goG i = hoistStep f2g <$> f2g (goF i)
 
 -- | Step is the core for running machines. Machines can either stop
 -- | via the `Halt` constructor, or emit a value and recursively
@@ -74,7 +75,7 @@ data Step f i o = Emit o (MealyT f i o) | Halt
 -- | in `g`, given a natural transformation from `f` to `g`.
 hoistStep :: forall f g i. Functor g => (f ~> g) -> Step f i ~> Step g i
 hoistStep f2g (Emit v nxt) = Emit v (hoistMealyT f2g nxt)
-hoistStep _   Halt         = Halt
+hoistStep _ Halt = Halt
 
 -- | Sources are 'initial nodes' in machines. They allow for data
 -- | to be generated.
@@ -92,7 +93,7 @@ type Sink f i = MealyT f i Unit
 -- | take 10 $ source (pure 1)
 -- | ```
 source :: forall f o. Functor f => f o -> Source f o
-source src =  mealy $ \_ -> flip Emit (source src) <$> src
+source src = mealy $ \_ -> flip Emit (source src) <$> src
 
 -- | Construct a machine which executes an effectful computation on its inputs.
 -- |
@@ -111,8 +112,9 @@ sink f = mealy $ \i -> const (Emit unit (sink f)) <$> f i
 -- | ```
 runMealy :: forall f. Monad f => MealyT f Unit Unit -> f Unit
 runMealy m = stepMealy unit m >>= f
-                where f Halt        = pure unit
-                      f (Emit _ m') = runMealy m'
+  where
+  f Halt = pure unit
+  f (Emit _ m') = runMealy m'
 
 -- | Execute (unroll) a single step on a machine.
 stepMealy :: forall f i o. i -> MealyT f i o -> f (Step f i o)
@@ -146,17 +148,23 @@ halt = pureMealy $ const Halt
 -- | Limit the number of outputs of a machine. After using up the `n`
 -- | allotted outputs, the machine will halt.
 take :: forall f i o. Applicative f => Int -> MealyT f i o -> MealyT f i o
-take n m  = if n <= 0 then halt
-              else mealy $ \i ->  f <$> stepMealy i m
-                                  where f Halt        = Halt
-                                        f (Emit o m') = Emit o (take (n - 1) m')
+take n m =
+  if n <= 0 then halt
+  else mealy $ \i -> f <$> stepMealy i m
+  where
+  f Halt = Halt
+  f (Emit o m') = Emit o (take (n - 1) m')
 
 -- | Skip a number of outputs for a machine.
 drop :: forall f i o. Monad f => Int -> MealyT f i o -> MealyT f i o
-drop n m  = if n <= 0 then m
-              else mealy $ \i ->  let f Halt        = pure Halt
-                                      f (Emit _ m') = stepMealy i (drop (n - 1) m')
-                                  in  stepMealy i m >>= f
+drop n m =
+  if n <= 0 then m
+  else mealy $ \i ->
+    let
+      f Halt = pure Halt
+      f (Emit _ m') = stepMealy i (drop (n - 1) m')
+    in
+      stepMealy i m >>= f
 
 -- | Loop a machine forever.
 loop :: forall f i o. Monad f => MealyT f i o -> MealyT f i o
@@ -172,12 +180,14 @@ toUnfoldable
   :: forall f g i o
    . Unfoldable g
   => Comonad f
-  => i -> MealyT f i o -> g o
+  => i
+  -> MealyT f i o
+  -> g o
 toUnfoldable i = unfoldr stepUnfold
   where
   stepUnfold m = case extract (runMealyT m i) of
     Emit o m' -> Just $ Tuple o m'
-    Halt      -> Nothing
+    Halt -> Nothing
 
 -- | Zip two machines together under some function `f`.
 zipWith :: forall f i a b c. Apply f => (a -> b -> c) -> MealyT f i a -> MealyT f i b -> MealyT f i c
@@ -185,10 +195,14 @@ zipWith f a b = f <$> a <*> b
 
 -- | Accumulate the outputs of a machine into a new machine.
 scanl :: forall f i a b. Functor f => (b -> a -> b) -> b -> MealyT f i a -> MealyT f i b
-scanl f = go where
-    go b m = mealy $ \i ->  let g Halt        = Halt
-                                g (Emit o m') = (let b' = f b o in Emit b' (go b' m'))
-                             in g <$> stepMealy i m
+scanl f = go
+  where
+  go b m = mealy $ \i ->
+    let
+      g Halt = Halt
+      g (Emit o m') = (let b' = f b o in Emit b' (go b' m'))
+    in
+      g <$> stepMealy i m
 
 -- | Accumulates the outputs of a machine as a `List`.
 collect :: forall f i o. Functor f => MealyT f i o -> MealyT f i (List o)
@@ -201,16 +215,19 @@ singleton o = pureMealy $ \_ -> Emit o halt
 -- | Creates a machine which either emits a single value before halting
 -- | (for `Just`), or just halts (in the case of `Nothing`).
 fromMaybe :: forall f i o. Applicative f => Maybe o -> MealyT f i o
-fromMaybe Nothing  = halt
+fromMaybe Nothing = halt
 fromMaybe (Just o) = singleton o
 
 -- | Creates a machine which emits all the values of the array before
 -- | halting.
 fromArray :: forall f i o. Monad f => Array o -> MealyT f i o
-fromArray o = let len = length o
-                  go n | n < zero || n >= len = halt
-                  go n                        = fromMaybe (o !! n) <> go (n + one)
-              in  go zero
+fromArray o =
+  let
+    len = length o
+    go n | n < zero || n >= len = halt
+    go n = fromMaybe (o !! n) <> go (n + one)
+  in
+    go zero
 
 -- | Creates a machine which wraps an effectful computation and ignores
 -- | its input.
@@ -221,9 +238,10 @@ wrapEffect fa = MealyT $ const (flip Emit halt <$> fa)
 -- | Unwrap a machine such that its output is either `Nothing` in case
 -- | it would halt, or `Just` the output value and the next computation.
 msplit :: forall f i o. Applicative f => MealyT f i o -> MealyT f i (Maybe (Tuple o (MealyT f i o)))
-msplit m = mealy $ \i ->  f <$> stepMealy i m
-  where f Halt         = Emit (Nothing) halt
-        f (Emit o m')  = Emit (Just $ Tuple o m') (msplit m')
+msplit m = mealy $ \i -> f <$> stepMealy i m
+  where
+  f Halt = Emit (Nothing) halt
+  f (Emit o m') = Emit (Just $ Tuple o m') (msplit m')
 
 -- | Interleaves the values of two machines with matching inputs and
 -- | outputs.
@@ -259,9 +277,10 @@ when :: forall f i a b. Monad f => MealyT f i a -> (a -> MealyT f i b) -> MealyT
 when ma f = ifte ma f halt
 
 instance functorMealy :: Functor f => Functor (MealyT f i) where
-  map f m = mealy $ \i -> g <$> stepMealy i m where
+  map f m = mealy $ \i -> g <$> stepMealy i m
+    where
     g (Emit o m') = Emit (f o) (f <$> m')
-    g Halt        = Halt
+    g Halt = Halt
 
 instance applyMealy :: Apply f => Apply (MealyT f i) where
   apply f x = mealy $ \i -> ap <$> stepMealy i f <*> stepMealy i x
@@ -274,23 +293,31 @@ instance applicativeMealy :: Applicative f => Applicative (MealyT f i) where
   pure t = pureMealy $ \_ -> Emit t halt
 
 instance profunctorMealy :: Functor f => Profunctor (MealyT f) where
-  dimap l r = remap where
-    remap m = mealy $ \i -> g <$> stepMealy (l i) m where
-                g (Emit c m') = Emit (r c) (remap m')
-                g Halt        = Halt
+  dimap l r = remap
+    where
+    remap m = mealy $ \i -> g <$> stepMealy (l i) m
+      where
+      g (Emit c m') = Emit (r c) (remap m')
+      g Halt = Halt
 
 instance strongMealy :: Functor f => Strong (MealyT f) where
-  first m = mealy $ \s -> let b = fst s
-                              d = snd s
-                              g (Emit c f') = Emit (Tuple c d) (first f')
-                              g Halt        = Halt
-                          in  g <$> stepMealy b m
+  first m = mealy $ \s ->
+    let
+      b = fst s
+      d = snd s
+      g (Emit c f') = Emit (Tuple c d) (first f')
+      g Halt = Halt
+    in
+      g <$> stepMealy b m
   second = dimap swap swap <<< first
 
 instance semigroupMealy :: Monad f => Semigroup (MealyT f i o) where
-  append l r = mealy $ \i ->  let g (Emit c l') = pure $ Emit c (l' <> r)
-                                  g Halt        = stepMealy i r
-                              in  stepMealy i l >>= g
+  append l r = mealy $ \i ->
+    let
+      g (Emit c l') = pure $ Emit c (l' <> r)
+      g Halt = stepMealy i r
+    in
+      stepMealy i l >>= g
 
 instance monoidMealy :: Monad f => Monoid (MealyT f i o) where
   mempty = mealy $ \_ -> pure Halt
@@ -298,29 +325,36 @@ instance monoidMealy :: Monad f => Monoid (MealyT f i o) where
 instance semigroupoidMealy :: Monad f => Semigroupoid (MealyT f) where
   compose f g =
     mealy $ \b -> stepMealy b g >>= gb
-    where gb Halt = pure Halt
-          gb (Emit c g') = fc <$> stepMealy c f
-            where
-            fc (Emit d f') = Emit d (f' <<< g')
-            fc Halt        = Halt
+    where
+    gb Halt = pure Halt
+    gb (Emit c g') = fc <$> stepMealy c f
+      where
+      fc (Emit d f') = Emit d (f' <<< g')
+      fc Halt = Halt
 
 instance categoryMealy :: Monad f => Category (MealyT f) where
   identity = pureMealy $ \t -> Emit t halt
 
 instance bindMealy :: Monad f => Bind (MealyT f i) where
-  bind m f = mealy $ \i -> let g (Emit o m') = h <$> stepMealy i (f o)
-                                 where
-                                 h (Emit b bi) = Emit b (bi <> (m' >>= f))
-                                 h Halt        = Halt
-                               g Halt        = pure Halt
-                           in  stepMealy i m >>= g
+  bind m f = mealy $ \i ->
+    let
+      g (Emit o m') = h <$> stepMealy i (f o)
+        where
+        h (Emit b bi) = Emit b (bi <> (m' >>= f))
+        h Halt = Halt
+      g Halt = pure Halt
+    in
+      stepMealy i m >>= g
 
 instance monadMealy :: Monad f => Monad (MealyT f i)
 
 instance altMealy :: Monad f => Alt (MealyT f i) where
-  alt x y = mealy $ \i -> let f Halt         = stepMealy i y
-                              f (Emit o m')  = pure $ Emit o m'
-                          in  stepMealy i x >>= f
+  alt x y = mealy $ \i ->
+    let
+      f Halt = stepMealy i y
+      f (Emit o m') = pure $ Emit o m'
+    in
+      stepMealy i x >>= f
 
 instance plusMealy :: Monad f => Plus (MealyT f i) where
   empty = halt


### PR DESCRIPTION

**Description of the change**
Introduces the [`purs-tidy`](https://github.com/natefaubion/purescript-tidy) formatter. This formatter is a lightly opinionated tool we use to maintain a consistent style in the contrib libraries.

We ordinarily restrict to tools provided by the `core` or `contrib` projects. This tool is not, but it was developed and is maintained by core team members, and because it's a formatter it can't block maintenance or release of this library even in the event something goes catastrophically wrong with it.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a link to this PR and your username
- [x] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation in the README and/or documentation directory
- [x] Added a test for the contribution (if applicable)
